### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - November 23, 2019
+
+### Added
+- Comment to FreeRam()
+
+### Changed
+- License to BSD-3
+- FreeRam() to return the "avalible" column not "free" column.
+
 ## [0.9.0] - October 10, 2019
 ### Added
 - In code instructions to enable battery status.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,26 @@
-MIT License
+Copyright 2019 Jaron R. Swab
 
-Copyright (c) 2019 J. R. Swab
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/blocks/ram.go
+++ b/blocks/ram.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// FreeRam is called every five seconds to display the current
+// ram avalible. Command used is `free` piped into gawk to return
+// the "available" (7th) column in the row labeled `Mem`.
 func FreeRam(cRam chan string, eRam chan error) {
 	var passed, tenSecs float64
 	start := time.Now() // set to determine seconds passed
@@ -19,7 +22,7 @@ func FreeRam(cRam chan string, eRam chan error) {
 
 		if passed < 5 || tenSecs == 0 { // trigger: asap or divisible by ten
 			ramFree := ""
-			ramCmd := "free -h | gawk '/Mem:/ {print $4}'" // set shell command
+			ramCmd := "free -h | gawk '/Mem:/ {print $7}'" // set shell command
 
 			ramGib, err := exec.Command("sh", "-c", ramCmd).Output() // run and save the output
 			if err != nil {


### PR DESCRIPTION
Changed to BSD-3

Changed FreeRam() to display "available".
Originally the `FreeRam()` function returned the "free" column of the command `free -h`. This update changes the return to be the "available" column instead.