### PR TITLE
Added CLI Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - January 06, 2020
+
+### Added
+- Polybar to the list of UI's
+
 ## [0.9.1] - November 23, 2019
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - January 06, 2020
 
 ### Added
-- Polybar to the list of UI's
+- CLI flag to enable DWM status bar out put `--dwm=true` to enable
+- CLI flag to enable batter status information.
+
+### Changed
+- `Status` formating for easier editing.
 
 ## [0.9.1] - November 23, 2019
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently tested with DWM, i3wm, and tmux.
 - Weather via wttr.in
 - Total RAM not used
 - Total disk space left in the binary's present partition.
-- Total battery percentage (commented out by default)
+- Total battery percentage (off by default)
 - Icons
 #### Current UIs:
 - DWM
@@ -17,20 +17,24 @@ Currently tested with DWM, i3wm, and tmux.
 - tmux
 - Polybar
 
+#### CLI Flags
+- `-dwm=true` to use in DWM's status bar
+- `-battery=true` to enable battery block
+
 ### Icons:
-To display icons in DWM.
-1. Install FontAwesome
+#### To display icons in DWM.
+1. Install Font Awesome 5
 2. Set FontAwesome as the second font in `dwm/config.h`
-   - eg. `static const char *fonts[] = { "Source Code Pro:size=13", "FontAwesome:size=14" };`
+   - eg. `static const char *fonts[] = { "Source Code Pro:size=13", "Font Awesome 5 Free:style=Regular:size=14" };`
 3. Relaunch DWM
 
-To display in tmux or i3wm:
-1. Install FontAwesome
+#### To display in tmux or i3wm:
+1. Install Font Awesome 5
    - Keep in mind that the icons are currently very small.
    - Research in progess.
 
-To display in Polybar:
-1. Install Font Awesome:
+#### To display in Polybar:
+1. Install Font Awesome 5:
 2. Add to your Polybar config:
 ```
 font-0 = {base font here}
@@ -56,33 +60,32 @@ If you have an easy way to display FontAwesome icons at the same scale as the te
 ## How To Use:
 1. Open main.go in a text editor.
 2. Edit the last `status` variable to contain the blocks you wish to use.
-3. Change the last line to match your UI (eg, `ui.Dwm(status)`).
-4. Build the binary.
-5. Edit your config file to use the new binary.
+3. Build the binary.
+4. Edit your config file to use the new binary.
+   - If using DWM execute with the `--dwm=true` flag.
 
 ### Adding to DWM:
-- Simply set `ui.Dwm(status)`, compile, and execute.
-- If you already have a startup script for DWM just add a new line for go-status
+- If you already have a startup script for DWM just add a new line with the path to this binary.
 
 ### Addng to Tmux:
 - `set -g status-right "#($HOME/PATHTO/tmux-status)"`
  - If you have colors in this setting add the path at the end of the string
  - Be sure to use the correct path and name of the file you built with GO.
- - Running `mv go-status ~/tmux-status` will allow you to use `"($HOME/tmux-status)"` in your config.
+ - Running `mv breto ~/tmux-status` will allow you to use `"($HOME/tmux-status)"` in your config.
 - `set -g status-right-length 53`
  - If you are not using all the custom packages this number can be lower
- - This also will vary based on screen size. 53 is the minimum that worke for all current blocks
+ - This also will vary based on screen size. 53 is the minimum that worked for all current blocks on my montior.
  - If you notice the status getting cut off just increase the number and reload tmux.
 
 ### Adding to i3wm:
-- In the i3wm confige file, change `status_command ...` to `status_command PATH/TO/go-status`
+- In the i3wm confige file, change `status_command ...` to `status_command PATH/TO/breto`
 
 ### Adding to Polybar:
 - Add the following module to your Polybar configuration file:
 ```
 [module/breto]
 type = custom/script
-exec = /home/jaron/custom-setup/breto
+exec = /path/to/breto
 tail = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,30 @@ Currently tested with DWM, i3wm, and tmux.
 - DWM
 - i3wm
 - tmux
+- Polybar
 
 ### Icons:
 To display icons in DWM.
-1. Install FontAwesome v4
+1. Install FontAwesome
 2. Set FontAwesome as the second font in `dwm/config.h`
    - eg. `static const char *fonts[] = { "Source Code Pro:size=13", "FontAwesome:size=14" };`
 3. Relaunch DWM
 
 To display in tmux or i3wm:
-1. Install FontAwesome v4.
+1. Install FontAwesome
    - Keep in mind that the icons are currently very small.
    - Research in progess.
+
+To display in Polybar:
+1. Install Font Awesome:
+2. Add to your Polybar config:
+```
+font-0 = {base font here}
+font-1 = "Font Awesome 5 Free:style=Regular:pixelsize=12;1"
+font-2 = "Font Awesome 5 Free:style=Solid:pixelsize=12;1"
+font-3 = "Font Awesome 5 Brands:pixelsize=12;1"
+```
+3. If not using Font Awesome 5 search for your version with `fc-list | grep Awesome`.
 
 #### Current Icons:
 - Tempurature: 
@@ -65,6 +77,15 @@ If you have an easy way to display FontAwesome icons at the same scale as the te
 ### Adding to i3wm:
 - In the i3wm confige file, change `status_command ...` to `status_command PATH/TO/go-status`
 
+### Adding to Polybar:
+- Add the following module to your Polybar configuration file:
+```
+[module/breto]
+type = custom/script
+exec = /home/jaron/custom-setup/breto
+tail = true
+```
+
 ## Wttr.in Options:
 1. Add your area to the weather function
    - Area Code: 'wttr.in/~00000?format=2' 
@@ -73,8 +94,7 @@ If you have an easy way to display FontAwesome icons at the same scale as the te
 2. Add tweaks to `blocks/wttr.go`
 
 ## To-Do:
-1. Get a proper name
-2. Scale icons in tmux and i3wm
+1. Scale icons in tmux and i3wm
    - [This Unix Stack Exchange post may help](http://unix.stackexchange.com/questions/49779/ddg#49823)
 
 ## License:

--- a/main.go
+++ b/main.go
@@ -115,6 +115,6 @@ func main() {
 			tempIco, stats.weather, homeDir, stats.homeSpace,
 			memIco, stats.ramFree, ico.volIcon, stats.volText,
 			stats.hTime, ico.dropbox, ico.syncthing, ico.rShift)
-		ui.Tmux(status) // change this to the UI of choice
+		ui.Polybar(status) // change this to the UI of choice
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 )
 
-// To have the status blocks appear in dwm we have to run xsetroot -name [status]
+// Dwm - To have the status blocks appear in dwm we have to run xsetroot -name [status]
 // where [status] contains the data blocks
 func Dwm(status string) error {
 	cmd := exec.Command("xsetroot", "-name", status)
@@ -13,7 +13,7 @@ func Dwm(status string) error {
 	return err
 }
 
-// For tmux we only need to output the block to stdout
+// Tmux - we only need to output the block to stdout
 // Add the following to your tmux config:
 // set -g status-right "#($HOME/PATHTO/go-status)"
 // where `go-status` is the compiled binary
@@ -21,11 +21,17 @@ func Tmux(status string) {
 	fmt.Println(status)
 }
 
-// For i3wm we only need to output the block to stdout as we do with tmux.
+// I3wm - we only need to output the block to stdout as we do with tmux.
 // Make sure to update the `bar {}` section in your i3wm
 // config file to the following:
 // status_command $HOME/PATH/TO/go-status
 // where `go-status` is the compiled binary
 func I3wm(status string) {
+	fmt.Println(status)
+}
+
+// Polybar - we only need to output the block to stdout as we do with tmux.
+// Add Font Awesome fonts to the Polybar config file.
+func Polybar(status string) {
 	fmt.Println(status)
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -13,25 +13,25 @@ func Dwm(status string) error {
 	return err
 }
 
-// Tmux - we only need to output the block to stdout
+// Default is used when we only need to output the block to stdout.
+// This is the default option.
+//
+// For tmux:
 // Add the following to your tmux config:
 // set -g status-right "#($HOME/PATHTO/go-status)"
 // where `go-status` is the compiled binary
-func Tmux(status string) {
-	fmt.Println(status)
-}
-
-// I3wm - we only need to output the block to stdout as we do with tmux.
+//
+// For i3wm:
 // Make sure to update the `bar {}` section in your i3wm
 // config file to the following:
 // status_command $HOME/PATH/TO/go-status
 // where `go-status` is the compiled binary
-func I3wm(status string) {
-	fmt.Println(status)
-}
-
-// Polybar - we only need to output the block to stdout as we do with tmux.
-// Add Font Awesome fonts to the Polybar config file.
-func Polybar(status string) {
+//
+// For Polybar:
+// [module/breto]
+// type = custom/script
+// exec = /path/to/breto/binary
+// tail = true
+func Default(status string) {
 	fmt.Println(status)
 }


### PR DESCRIPTION
Users can now use flags for enabling DWM and/or batter information.
Also updated the `status` string code to be easier to edit.

May add flags to to turn off blocks as the user desires.