### PR TITLE
More CLI Flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.dll
 *.so
 *.dylib
-go-status
+breto
 
 # Test binary, built with `go test -c`
 *.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - January 11, 2020
+
+### Added
+- CLI flags for the clock, audio, memory, diskSpace, temperature, and tray
+- `init()` to set up CLI flags instead.
+- Comments for each exported block function
+- Checks for CLI flags to disable go routines if the user disables a speific block
+
+### Changed
+- `status` build to includ if statments based off CLI flag variables.
+- CLI flag variables to be global after adding `init()`
+
+### Removed
+- `|` from all block returns.
+
 ## [0.10.0] - January 06, 2020
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Breto
 A status bar written in Go.
-Currently tested with DWM, i3wm, and tmux.
+Currently tested with DWM, i3wm, tmux, and Polybar.
 
 ## Current Features:
 ### Master Branch:
@@ -20,6 +20,12 @@ Currently tested with DWM, i3wm, and tmux.
 #### CLI Flags
 - `-dwm=true` to use in DWM's status bar
 - `-battery=true` to enable battery block
+- `-dateTime=false` to remove the date/time block
+- `-volume=false` to remove volume percentage block
+- `-ram=false` to remove RAM remaining block
+- `-storage=false` to remove the home directory storage remaining block
+- `-temp=false` to remove the weather block
+- `-tray=false` to remove the "system" tray block
 
 ### Icons:
 #### To display icons in DWM.

--- a/blocks/battery.go
+++ b/blocks/battery.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// Battery returns the current percentage remaining.
 func Battery() (string, error) {
 	cmd := "cat /sys/class/power_supply/BAT0/capacity"
 	runCmd, err := exec.Command("sh", "-c", cmd).Output()
@@ -14,6 +15,6 @@ func Battery() (string, error) {
 	}
 
 	perc := "%"
-	level := fmt.Sprintf("%s%s |", strings.TrimSpace(string(runCmd)), perc)
+	level := fmt.Sprintf("%s%s", strings.TrimSpace(string(runCmd)), perc)
 	return level, nil
 }

--- a/blocks/disk.go
+++ b/blocks/disk.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// HomeDisk returns the remaining home directory storage space in GiB
 func HomeDisk(cHomeDisk chan string, eHomeDisk chan error) {
 	// df -h | awk '/home/ {print $4}
 	var passed, hour float64
@@ -26,7 +27,7 @@ func HomeDisk(cHomeDisk chan string, eHomeDisk chan error) {
 				eHomeDisk <- err
 			}
 
-			homeFree = fmt.Sprintf("%s |", strings.TrimSpace(string(homeOut)))
+			homeFree = fmt.Sprintf("%s", strings.TrimSpace(string(homeOut)))
 			cHomeDisk <- homeFree
 		}
 	}

--- a/blocks/ram.go
+++ b/blocks/ram.go
@@ -29,7 +29,7 @@ func FreeRam(cRam chan string, eRam chan error) {
 				eRam <- err
 			}
 
-			ramFree = fmt.Sprintf("%s |",
+			ramFree = fmt.Sprintf("%s",
 				strings.TrimSpace(string(ramGib))) // set string
 
 			cRam <- ramFree // send string

--- a/blocks/volume.go
+++ b/blocks/volume.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// VolumeText sends back the current volume percent.
 func VolumeText() (string, error) {
 	volCmd := "amixer -D pulse sget Master | awk '/Front Right:/ {print $5}' | grep -o '[0-9].'"
 	runVol, err := exec.Command("sh", "-c", volCmd).Output()
@@ -14,5 +15,5 @@ func VolumeText() (string, error) {
 	}
 
 	percent := "%"
-	return fmt.Sprintf("%s%s |", strings.TrimSpace(string(runVol)), percent), nil
+	return fmt.Sprintf("%s%s", strings.TrimSpace(string(runVol)), percent), nil
 }

--- a/blocks/wttr.go
+++ b/blocks/wttr.go
@@ -37,7 +37,7 @@ func Wttr(cWttr chan string, eWttr chan error) {
 			// Several attempts to catch the exact error proved difficult
 			// so now we catch the correct outupt instead.
 			if strings.Contains(data, "+") || strings.Contains(data, "-") {
-				weather = fmt.Sprintf("%s |", strings.TrimSpace(data))
+				weather = fmt.Sprintf("%s", strings.TrimSpace(data))
 				cWttr <- weather
 			} else {
 				eWttr <- fmt.Errorf("Expected temp, got: %s", data)


### PR DESCRIPTION
Added more CLI flags and set them within `init()`.
Go Routines will now only execute if the correct flags are set to true.
Added comments to block exported functions
Removed `|` from block outputs.